### PR TITLE
Carrierwaveローカルとデプロイ環境で設定変更

### DIFF
--- a/app/uploaders/image_uploader.rb
+++ b/app/uploaders/image_uploader.rb
@@ -5,7 +5,7 @@ class ImageUploader < CarrierWave::Uploader::Base
   process resize_to_fit: [200, 200]
   # Choose what kind of storage to use for this uploader:
   # storage :file
-  storage :fog
+  # storage :fog
 
   # Override the directory where uploaded files will be stored.
   # This is a sensible default for uploaders that are meant to be mounted:

--- a/config/initializers/carrierwave.rb
+++ b/config/initializers/carrierwave.rb
@@ -3,6 +3,10 @@ require 'carrierwave/storage/file'
 require 'carrierwave/storage/fog'
 
 CarrierWave.configure do |config|
+  if Rails.env.development? || Rails.env.test?
+    config.storage = :file
+  else
+
   config.storage = :fog
   config.fog_provider = 'fog/aws'
   config.fog_credentials = {

--- a/config/initializers/carrierwave.rb
+++ b/config/initializers/carrierwave.rb
@@ -18,4 +18,5 @@ CarrierWave.configure do |config|
 
   config.fog_directory  = 'mercari47a'
   config.asset_host = 'https://s3-ap-northeast-1.amazonaws.com/mercari47a'
+  end
 end


### PR DESCRIPTION
現在マスターからプルした際、デプロイ環境であるAWSへアクセスできるのがデプロイ担当者のみであり、他の担当者はcarrierwaveの設定をimage_uproader.rbのstorage:fogを消し、storage:fileを復活させ、config→initializers→carrierwave.rbをコメントアウトすることでローカルでの画像保存ができています。

これをプルするたび毎回しなくても、環境が開発環境かプロダクション環境かでAWSのS３にアクセスするかローカルに保存するかできるようなので、その設定をこのプルリクエスト で記述しました。