### PR TITLE
edit-database

### DIFF
--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -1,5 +1,5 @@
 class Item < ApplicationRecord
-  belongs_to :saler, class_name: "User"
+  belongs_to :user
   has_one :trade
   has_many :images
   # belongs_to :brand

--- a/db/migrate/20190402105310_rename_saler_id_column_to_user_id.rb
+++ b/db/migrate/20190402105310_rename_saler_id_column_to_user_id.rb
@@ -1,7 +1,7 @@
 class RenameSalerIdColumnToUserId < ActiveRecord::Migration[5.0]
   def change
     rename_column :items, :saler_id, :user_id
-    rename_column :items:, :state, :item_condition
-    rename_column :items:, :status, :trade_status
+    rename_column :items, :state, :item_condition
+    rename_column :items, :status, :trade_status
   end
 end

--- a/db/migrate/20190402105310_rename_saler_id_column_to_user_id.rb
+++ b/db/migrate/20190402105310_rename_saler_id_column_to_user_id.rb
@@ -1,0 +1,7 @@
+class RenameSalerIdColumnToUserId < ActiveRecord::Migration[5.0]
+  def change
+    rename_column :items, :saler_id, :user_id
+    rename_column :items:, :state, :item_condition
+    rename_column :items:, :status, :trade_status
+  end
+end

--- a/db/migrate/20190402105906_change_datatype_status_of_items.rb
+++ b/db/migrate/20190402105906_change_datatype_status_of_items.rb
@@ -1,5 +1,5 @@
 class ChangeDatatypeStatusOfItems < ActiveRecord::Migration[5.0]
   def change
-    change_column :items, :status, :string
+    change_column :items, :trade_status, :string
   end
 end

--- a/db/migrate/20190402105906_change_datatype_status_of_items.rb
+++ b/db/migrate/20190402105906_change_datatype_status_of_items.rb
@@ -1,0 +1,5 @@
+class ChangeDatatypeStatusOfItems < ActiveRecord::Migration[5.0]
+  def change
+    change_column :items, :integer, :string
+  end
+end

--- a/db/migrate/20190402105906_change_datatype_status_of_items.rb
+++ b/db/migrate/20190402105906_change_datatype_status_of_items.rb
@@ -1,5 +1,5 @@
 class ChangeDatatypeStatusOfItems < ActiveRecord::Migration[5.0]
   def change
-    change_column :items, :integer, :string
+    change_column :items, :status, :string
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190401051827) do
+ActiveRecord::Schema.define(version: 20190402105906) do
 
   create_table "comments", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.integer  "user_id"
@@ -43,21 +43,21 @@ ActiveRecord::Schema.define(version: 20190401051827) do
   end
 
   create_table "items", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
-    t.string   "name",                                   null: false
-    t.text     "description", limit: 65535,              null: false
-    t.integer  "status",                    default: 1,  null: false
-    t.string   "price",                                  null: false
-    t.integer  "saler_id",                               null: false
-    t.string   "state",                                  null: false
-    t.integer  "category_id",                            null: false
-    t.integer  "brand_id",                  default: 1,  null: false
-    t.string   "saizu",                     default: "", null: false
-    t.datetime "created_at",                             null: false
-    t.datetime "updated_at",                             null: false
+    t.string   "name",                                       null: false
+    t.text     "description",    limit: 65535,               null: false
+    t.string   "trade_status",                 default: "1", null: false
+    t.string   "price",                                      null: false
+    t.integer  "user_id",                                    null: false
+    t.string   "item_condition",                             null: false
+    t.integer  "category_id",                                null: false
+    t.integer  "brand_id",                     default: 1,   null: false
+    t.string   "saizu",                        default: "",  null: false
+    t.datetime "created_at",                                 null: false
+    t.datetime "updated_at",                                 null: false
     t.index ["brand_id"], name: "index_items_on_brand_id", using: :btree
     t.index ["category_id"], name: "index_items_on_category_id", using: :btree
     t.index ["name"], name: "index_items_on_name", using: :btree
-    t.index ["saler_id"], name: "index_items_on_saler_id", using: :btree
+    t.index ["user_id"], name: "index_items_on_user_id", using: :btree
   end
 
   create_table "prefectures", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|


### PR DESCRIPTION
# what
データベースの修正

# why
カラム名をわかりやすくするため
usersテーブルとitemsテーブルのアソシエーションが組めていなかったため
