### PR TITLE
商品出品サーバーサイドカラム変更対応

### DIFF
--- a/app/assets/stylesheets/modules/_buysindex.scss
+++ b/app/assets/stylesheets/modules/_buysindex.scss
@@ -53,6 +53,10 @@
   background:gray;
   color:white;
   margin:30px auto;
+  text-decoration: none;
+  text-align: center;
+  box-sizing:border-box;
+  padding-top:10px;
  }
 
 #itembuybutton__point{

--- a/app/controllers/buys_controller.rb
+++ b/app/controllers/buys_controller.rb
@@ -1,19 +1,33 @@
 class BuysController < ApplicationController
   def new
-    @item=Item.find(itembuy_params[:item_id])
+    buyitem
+    @trade=@item.trade
   end
 
   def create
-    @item=Item.find(itembuy_params[:item_id])
-    @item.trade_status = 3
-    @item.save
+
   end
 
   def index
   end
 
+
+  def update
+    buyitem
+    if @item.trade_status == 3
+      redirect_to buys_index_path
+    else
+      @item.trade_status = 3
+      @item.save
+    end
+  end
+
   private
   def itembuy_params
     params.permit(:item_id)
+  end
+
+  def buyitem
+    @item=Item.find(itembuy_params[:item_id])
   end
 end

--- a/app/controllers/buys_controller.rb
+++ b/app/controllers/buys_controller.rb
@@ -1,10 +1,19 @@
 class BuysController < ApplicationController
   def new
+    @item=Item.find(itembuy_params[:item_id])
   end
 
   def create
+    @item=Item.find(itembuy_params[:item_id])
+    @item.trade_status = 3
+    @item.save
   end
 
   def index
+  end
+
+  private
+  def itembuy_params
+    params.permit(:item_id)
   end
 end

--- a/app/controllers/buys_controller.rb
+++ b/app/controllers/buys_controller.rb
@@ -23,6 +23,7 @@ class BuysController < ApplicationController
   end
 
   private
+
   def itembuy_params
     params.permit(:item_id)
   end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -34,7 +34,7 @@ class ItemsController < ApplicationController
 
   private
   def item_params
-      params.require(:item).permit(:name, :description,:price,:state,:status,:saler_id,:category_id,:brand_id,:saizu,trade_attributes: [:postage,:region,:shipping_date,:delivery])
+      params.require(:item).permit(:name, :description,:price,:item_condition,:trade_status,:user_id,:category_id,:brand_id,:saizu,trade_attributes: [:postage,:region,:shipping_date,:delivery])
 
   end
 

--- a/app/uploaders/image_uploader.rb
+++ b/app/uploaders/image_uploader.rb
@@ -5,7 +5,7 @@ class ImageUploader < CarrierWave::Uploader::Base
   process resize_to_fit: [200, 200]
   # Choose what kind of storage to use for this uploader:
 
-  storage :file
+  # storage :file
 
 
   # storage :fog

--- a/app/views/buys/create.html.haml
+++ b/app/views/buys/create.html.haml
@@ -4,6 +4,6 @@
     .sell__form__introduction
       商品は既に売り切れています
     .sell__form__itembuy
-      = link_to "商品画面へ戻る", user_path(:id), class: 'itemsnewlink itemsnewlink__notice'
+      = link_to "商品画面へ戻る", item_path(:"#{@item.id}"), class: 'itemsnewlink itemsnewlink__notice'
   =render 'shared/mercari-footer'
 

--- a/app/views/buys/new.html.haml
+++ b/app/views/buys/new.html.haml
@@ -17,7 +17,7 @@
         =@item.price
         <br><br>
         配送先と支払い方法の入力を完了してください。
-        = link_to "購入する", item_buys_path, class: 'itembuybutton',id:'itembuybutton__buy',method: :post
+        = link_to "購入する", 'item_buy(@trade)', class: 'itembuybutton',id:'itembuybutton__buy',method: :patch
     .buy__form__content
       .buy__form__content__cover
         配送先<br><br>

--- a/app/views/buys/new.html.haml
+++ b/app/views/buys/new.html.haml
@@ -6,14 +6,18 @@
     .buy__form__content
       .buy__form__content__cover
         .buy__form__content__cover__image
-          =image_tag "user-joukyo.png",size: "200x200", id: "itemnewimage"
+          =image_tag "#{@item.images[0].image}",size: "200x200", id: "itemnewimage"
           .buy__form__content__cover__image__input
-            Tシャツ アンパンマン<br>¥ 499 送料込み
+            =@item.name
+            <br>¥
+            =@item.price
+            送料込み
           %input.itembuybutton#itembuybutton__point{type:'button',value:'ポイントを使う'}
-        支払い金額 ¥ 499<br>
-        <br>
+        支払い金額 ¥
+        =@item.price
+        <br><br>
         配送先と支払い方法の入力を完了してください。
-        %input.itembuybutton#itembuybutton__buy{type:"button",value:"購入する"}
+        = link_to "購入する", item_buys_path, class: 'itembuybutton',id:'itembuybutton__buy',method: :post
     .buy__form__content
       .buy__form__content__cover
         配送先<br><br>

--- a/app/views/buys/update.html.haml
+++ b/app/views/buys/update.html.haml
@@ -4,6 +4,6 @@
     .sell__form__introduction
       商品は既に売り切れています
     .sell__form__itembuy
-      = link_to "商品画面へ戻る", item_path(:"#{@item.id}"), class: 'itemsnewlink itemsnewlink__notice'
+      = link_to "商品画面へ戻る", item_path(@item), class: 'itemsnewlink itemsnewlink__notice'
   =render 'shared/mercari-footer'
 

--- a/app/views/items/new.html.haml
+++ b/app/views/items/new.html.haml
@@ -32,8 +32,8 @@
         .sell__form__itemdescription__right__description
           カテゴリー
           %span.sell__form--need 必須
-          = f.select :saler_id,["1","2"],{},{class:'sell__form__itemdescription__right__descriptionselect'}
-          / = f.select :status,["1","2"],{},{class:'sell__form__itemdescription__right__descriptionselect'}
+          = f.select :user_id,["1","2"],{},{class:'sell__form__itemdescription__right__descriptionselect'}
+          / = f.select :trade_status,["1","2"],{},{class:'sell__form__itemdescription__right__descriptionselect'}
           = f.select :category_id,["1","2"],{},{class:'sell__form__itemdescription__right__descriptionselect'}
         .sell__form__itemdescription__right__description
           サイズ
@@ -46,7 +46,7 @@
         .sell__form__itemdescription__right__description
           商品の状態
           %span.sell__form--need 必須
-          = f.select :state,["新品、未使用","未使用に近い","傷や汚れあり","全体的に状態が悪い"],{},{class:'sell__form__itemdescription__right__descriptionselect'}
+          = f.select :item_condition,["新品、未使用","未使用に近い","傷や汚れあり","全体的に状態が悪い"],{},{class:'sell__form__itemdescription__right__descriptionselect'}
 
 
 

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -118,7 +118,7 @@
         = link_to buys_index_path do
           .item__confirmation-box__link-text2 売り切れました
       - else
-        = link_to new_item_buy_path(:"#{@item.id}") do
+        = link_to new_item_buy_path(@item) do
           .item__confirmation-box__link-text 購入画面に進む
 
     .item__text-box

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -8,7 +8,7 @@
         = @item.name
     .item__main-box
       .item__main-box__left
-        - if @item.status == 3
+        - if @item.trade_status == "3"
           .item__main-box__left__triangle
             .item__main-box__left__triangle__box SOLD
         .item__main-box__left__image-big
@@ -44,14 +44,14 @@
             .item__main-box__right__column-right__box__exhibitor-top
               = link_to user_path(@item) do
                 %p.item__main-box__right__column-right__box__exhibitor-top__link-text.item__main-box__right__column-right__box__links
-                  = @item.saler.nickname
+                  = @item.user.nickname
 
             .item__main-box__right__column-right__box__exhibitor-bottom
               .item__main-box__right__column-right__box__exhibitor-bottom__box-good
                 %i.fas.fa-laugh
                 .item__main-box__right__column-right__box__exhibitor-bottom__box-good__value
                   - num = 0
-                  - @item.saler.uservaluations.each do |kind|
+                  - @item.user.uservaluations.each do |kind|
                     - if kind.kind == "good"
                       - num += 1
                   = num
@@ -59,7 +59,7 @@
                 %i.fas.fa-meh
                 .item__main-box__right__column-right__box__exhibitor-bottom__box-normal__value
                   - num = 0
-                  - @item.saler.uservaluations.each do |kind|
+                  - @item.user.uservaluations.each do |kind|
                     - if kind.kind == "normal"
                       - num += 1
                   = num
@@ -67,7 +67,7 @@
                 %i.fas.fa-frown
                 .item__main-box__right__column-right__box__exhibitor-bottom__box-bad__value
                   - num = 0
-                  - @item.saler.uservaluations.each do |kind|
+                  - @item.user.uservaluations.each do |kind|
                     - if kind.kind == "bad"
                       - num += 1
                   = num
@@ -91,7 +91,7 @@
             = link_to root_path do
               %p.item__main-box__right__column-right__box__link-text.item__main-box__right__column-right__box__links ナイキ
           #item__main-box__right__column-right__state.item__main-box__right__column-right__box
-            = @item.state
+            = @item.item_condition
           #item__main-box__right__column-right__burden.item__main-box__right__column-right__box
             = @item.trade.postage
           #item__main-box__right__column-right__method.item__main-box__right__column-right__box
@@ -114,11 +114,11 @@
         - else
           送料込み
     .item__confirmation-box
-      - if @item.status == 3
-        = link_to buys_create_path do
+      - if @item.trade_status == "3"
+        = link_to buys_index_path do
           .item__confirmation-box__link-text2 売り切れました
       - else
-        = link_to buys_new_path do
+        = link_to new_item_buy_path(:"#{@item.id}") do
           .item__confirmation-box__link-text 購入画面に進む
 
     .item__text-box

--- a/app/views/shared/_comment.html.haml
+++ b/app/views/shared/_comment.html.haml
@@ -7,7 +7,7 @@
         .comment__comments-box__comment__left__text__name 出品者
   .comment__comments-box__comment__right
     .comment__comments-box__comment__right__title
-      = @item.saler.nickname
+      = @item.user.nickname
     .comment__comments-box__comment__right__message
       .comment__comments-box__comment__right__message__text
         おまたせしました。

--- a/config/initializers/carrierwave.rb
+++ b/config/initializers/carrierwave.rb
@@ -1,21 +1,6 @@
-# require 'carrierwave/storage/abstract'
-# require 'carrierwave/storage/file'
-# require 'carrierwave/storage/fog'
-
-
-# CarrierWave.configure do |config|
-#   config.storage = :fog
-#   config.fog_provider = 'fog/aws'
-#   config.fog_credentials = {
-#     provider: 'AWS',
-#     aws_access_key_id: Rails.application.secrets.aws_access_key_id,
-#     aws_secret_access_key: Rails.application.secrets.aws_secret_access_key,
-#     region: 'ap-northeast-1'
-#   }
-
-#   config.fog_directory  = 'mercari47a'
-#   config.asset_host = 'https://s3-ap-northeast-1.amazonaws.com/mercari47a'
-# end
+require 'carrierwave/storage/abstract'
+require 'carrierwave/storage/file'
+require 'carrierwave/storage/fog'
 
 CarrierWave.configure do |config|
   if Rails.env.development? || Rails.env.test?

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,7 +11,7 @@ Rails.application.routes.draw do
   root 'items#index'
   resources :users
   resources :items do
-    resources :buys, only: [:new,:create]
+    resources :buys, only: [:new,:create,:update]
     resources :comments
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,9 +3,7 @@ Rails.application.routes.draw do
 
   get 'creditcards/edit'
 
-  get 'buys/new'
 
-  get 'buys/create'
 
   get 'buys/index'
 
@@ -13,6 +11,7 @@ Rails.application.routes.draw do
   root 'items#index'
   resources :users
   resources :items do
+    resources :buys, only: [:new,:create]
     resources :comments
   end
 


### PR DESCRIPTION
１、商品カラム変更対応コミット→カラム名を変更したのに対応し、商品関係のビューやコントローラを修正しました。
saler_id→user_id
status→trade_status
state→item_condition

２、商品購入機能コミット→商品購入の機能を実装。商品を選択し、購入ボタンを押すとtrade_statusのレコードを売却済みを表すものに変える仕様です。

https://gyazo.com/21c155cc51704d4a1dc8b2de235f6e43

３、carrierwave設定コミット→https://github.com/usualpn0221/freemarket_sample_47a/pull/63のプルリクエスト で変更した内容が他のプルリクエスト で戻ってしまったため再コミット


