### PR TITLE
fix slideshow

### DIFF
--- a/app/assets/javascripts/slick.js
+++ b/app/assets/javascripts/slick.js
@@ -1,18 +1,21 @@
-$(document).ready(function(){
+$(document).on('turbolinks:load', function() {
   $('.slides').slick({
     accessibility: true,
     autoplay: true,
     dots: true,
     arrows: true,
     centerMode: true,
-    autoplaySpeed: 3000,
-    speed: 3000,
+    autoplaySpeed: 2000,
+    speed: 1000,
     pauseOnDotsHover: true,
     fade: true,
-    infinite:true,
-    focusOnSelect:true,
-    swipe:true,
+    infinite: true,
+    focusOnSelect: true,
+    swipe: true,
     slidesToShow: 1,
     slidesToScroll: 1,
+    cssEase: 'ease-in-out',
+    centerPadding:'5%',
+    focusOnSelect:true,
   });
 });


### PR DESCRIPTION
# what
別ページからトップページに飛んだ際にスライドが縦に並んでしまう問題の解決。(turbolinksの記述を追加することでなぜか直りました)

# why
ビューの崩れをなくすため