### PR TITLE
add-breadcrumb-in-profile

### DIFF
--- a/app/views/profiles/show.html.haml
+++ b/app/views/profiles/show.html.haml
@@ -1,5 +1,8 @@
 = render 'shared/header'
 .default-container
+  %nav.bread-container
+    - breadcrumb :profile
+    = breadcrumbs separator: "#{content_tag(:i, '', :class=>'fas fa-chevron-right')}"
   %main.l-container
     = render 'shared/mypage-left-bar'
     = render 'shared/user-profile'

--- a/config/breadcrumbs.rb
+++ b/config/breadcrumbs.rb
@@ -11,3 +11,8 @@ crumb :item do |item|
   link "#{item.name}", item_path(item)
   parent :root
 end
+
+crumb :profile do
+  link 'プロフィール', profile_path
+  parent :mypage
+end


### PR DESCRIPTION
# what
プロフィールページにパンくずリストの導入

# why
プロフィールページからマイページ、ホームへ辿れるように