### PR TITLE
add-breadcrumbs-in-confirmation

### DIFF
--- a/app/views/shared/_mypage-left-bar.html.haml
+++ b/app/views/shared/_mypage-left-bar.html.haml
@@ -101,7 +101,7 @@
           %i.fas.fa-angle-right
     %ul.mypage-nav__list
       %li
-        =link_to "#", class:"mypage-nav__list__item" do
+        =link_to edit_user_path(current_user.id), class:"mypage-nav__list__item" do
           本人情報
           %i.fas.fa-angle-right
     %ul.mypage-nav__list

--- a/app/views/users/edit.html.haml
+++ b/app/views/users/edit.html.haml
@@ -1,5 +1,8 @@
 = render 'shared/header'
 .default-container
+  %nav.bread-container
+    - breadcrumb :confirmation
+    = breadcrumbs separator: "#{content_tag(:i, '', :class=>'fas fa-chevron-right')}"
   %main.l-container
     = render 'shared/mypage-left-bar'
     .right-content.credit-content

--- a/config/breadcrumbs.rb
+++ b/config/breadcrumbs.rb
@@ -21,3 +21,8 @@ crumb :logout do
   link 'ログアウト', destroy_user_session_path(current_user.id)
   parent :mypage
 end
+
+crumb :confirmation do
+  link '本人情報の登録', edit_user_path(current_user.id)
+  parent :mypage
+end


### PR DESCRIPTION
# what
パンくずリストの導入(本人情報確認ページ)

# why
本人確認情報ページからマイページ、ホームへ辿れるようにするため
