### PR TITLE
add-breadcrumbs-in-payment

### DIFF
--- a/app/views/creditcards/index.html.haml
+++ b/app/views/creditcards/index.html.haml
@@ -1,5 +1,8 @@
 = render 'shared/header'
 .default-container
+  %nav.bread-container
+    - breadcrumb :method
+    = breadcrumbs separator: "#{content_tag(:i, '', :class=>'fas fa-chevron-right')}"
   %main.l-container
     .right-content.credit-content
       .sell__form__introduction
@@ -7,7 +10,7 @@
       .credit-content__intro
         クレジットカード一覧
       .sell__form__button__back
-        = link_to "□ クレジットカードを追加する", creditcards_edit_path, class: 'itemsnewlink__backbutton credit-content__link'
+        = link_to "□ クレジットカードを追加する", edit_creditcard_path(1), class: 'itemsnewlink__backbutton credit-content__link'
       .credit-content__notice
         = link_to "支払い方法について >", user_path(:id), class: 'itemsnewlink itemsnewlink__notice'
     = render 'shared/mypage-left-bar'

--- a/app/views/shared/_mypage-left-bar.html.haml
+++ b/app/views/shared/_mypage-left-bar.html.haml
@@ -91,8 +91,8 @@
           %i.fas.fa-angle-right
     %ul.mypage-nav__list
       %li
-        =link_to "#", class:"mypage-nav__list__item" do
-          支払い方法
+        =link_to creditcards_path, class:"mypage-nav__list__item" do
+          支払い情報
           %i.fas.fa-angle-right
     %ul.mypage-nav__list
       %li

--- a/config/breadcrumbs.rb
+++ b/config/breadcrumbs.rb
@@ -26,3 +26,8 @@ crumb :confirmation do
   link '本人情報の登録', edit_user_path(current_user.id)
   parent :mypage
 end
+
+crumb :method do
+  link '支払い方法', edit_creditcard_path(1)
+  parent :mypage
+end


### PR DESCRIPTION
# what
支払い情報ページにパンくずリストの導入

# why
支払い情報ページからマイページ、ホームへ辿れるようにするため
