### PR TITLE
fix-items-show-page

### DIFF
--- a/app/assets/stylesheets/modules/_items-show.scss
+++ b/app/assets/stylesheets/modules/_items-show.scss
@@ -377,6 +377,7 @@
           font-weight: 700;
           color: $white;
           background-color: #888888;
+          cursor: not-allowed;
         }
       }
     }
@@ -583,7 +584,6 @@
       background-color: $white;
       padding: 24px;
       box-sizing: border-box;
-      // = form_for [@items, @comment] do |f|
       &__top-text {
         padding: 8px;
         box-sizing: border-box;
@@ -599,6 +599,7 @@
         margin-top: 8px;
         background-color: #f5f5f5;
         border: 1px solid #CCCCCC;
+        outline: none;
       }
       &__action-box {
         width: 652px;
@@ -607,7 +608,16 @@
         height: 50px;
         background-color: #aaaaaa;
         margin-top: 8px;
-        &__btn {
+        &__btn1 {
+          color: $white;
+          height: 50px;
+          background-color: #aaaaaa;
+          font-size: 14px;
+          width: 652px;
+          border-style: none;
+          cursor: not-allowed;
+        }
+        &__btn2 {
           color: $white;
           height: 50px;
           background-color: #aaaaaa;

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -1,6 +1,5 @@
 class CommentsController < ApplicationController
-
-  # def new
-  #   @comment = Comment.new
-  # end
+  def create
+    redirect_to root_path
+  end
 end

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -125,7 +125,7 @@
     - else
       .item__confirmation-box
         - if @item.trade_status == "3"
-          = link_to buys_index_path do
+          = link_to root_path do
             .item__confirmation-box__link-text2 売り切れました
         - else
           = link_to new_item_buy_path(@item) do
@@ -173,7 +173,10 @@
           相手のことを考え丁寧なコメントを心がけましょう。不快な言葉遣いなどは利用制限や退会処分となることがあります。
         = f.text_field :text, class: 'comment__form-box__input'
         .comment__form-box__action-box
-          = f.submit 'コメントする', class: 'comment__form-box__action-box__btn'
+          - if @item.trade_status == "3"
+            = f.submit '売り切れのためコメントできません', class: 'comment__form-box__action-box__btn1'
+          - else
+            = f.submit 'コメントする', class: 'comment__form-box__action-box__btn2'
   .nav
     .nav__left
       = link_to "https://item.mercari.com/jp/m65619776524/" do


### PR DESCRIPTION
# what
「コメントする」、「売り切れました」を押したときにエラー画面が表示されていたので、ルートパスに飛ばすように変更

# why
エラー画面が表示されないようにするため
