### PR TITLE
fix-slick

### DIFF
--- a/app/assets/stylesheets/modules/_toppage.scss
+++ b/app/assets/stylesheets/modules/_toppage.scss
@@ -224,14 +224,19 @@
 .slide-dots{
   text-align: center;
   position: absolute;
-  top: 88%;
-  right: 50%;
+  top: 85%;
+  right: 47%;
   li{
     display: inline-block;
     margin: 0 15px;
     button{
       position: relative;
       text-indent: -9999px;
+      right: -190%;
+      color: transparent;
+      background: transparent;
+      border: transparent;
+      outline: none;
       &:before{
         content: '●';
         color: #fff;


### PR DESCRIPTION
# what
トップページのメルカリロゴからトップページに遷移したときに、スライドショーのドットのレイアウトが崩れてしまう問題の修正

なぜかドット間の間隔が広くなってしまいますが、枠を透明にすることで応急処置的な対応をしています

# why
レイアウトの崩れを治すため