### PR TITLE
マルチステップフォームの修正

### DIFF
--- a/app/assets/stylesheets/modules/_signup.scss
+++ b/app/assets/stylesheets/modules/_signup.scss
@@ -70,11 +70,25 @@
   width: 50%;
   margin: 40px auto 0;
   font-size: 20px;
-  .signin__user-infomation__thanks{
+  &__thanks{
     font-size: 3px;
   }
   &__complete{
     font-size: 20px;
+  }
+  &__btn{
+    background: #ea352d;
+    border: 1px solid #ea352d;
+    color: #fff;
+    margin-top: 40px;
+    width: 100%;
+    line-height: 48px;
+    font-size: 18px;
+    padding: 0 20px;
+    &__start{
+      color: white;
+      text-decoration: none;
+    }
   }
   .ur-form-group {
     width:100%;

--- a/app/controllers/address_controller.rb
+++ b/app/controllers/address_controller.rb
@@ -1,4 +1,5 @@
 class AddressController < ApplicationController
+  skip_before_action :delete_user
   def new
     @profiles=Profile.new
   end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -26,8 +26,6 @@ class ApplicationController < ActionController::Base
   end
 
   def delete_user
-    @user_profile =Profile.where(user_id: current_user.id)
-    @user_phonenumber = Phonenumber.where(user_id: current_user.id)
     @registrations=User.find(current_user.id)
     @registrations.destroy if Profile.where(user_id: current_user.id).empty? || Phonenumber.where(user_id: current_user.id).empty? || @user_card =Card.where(user_id: current_user.id).empty?
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -27,8 +27,7 @@ class ApplicationController < ActionController::Base
 
   def delete_user
     @registrations=User.find(current_user.id)
-    binding.pry
-    @registrations.destroy unless Profile.where(user_id: current_user.id).exists? || Phonenumber.where(user_id: current_user.id).exists? || @user_card =Card.where(user_id: current_user.id).exists?
+    @registrations.destroy unless Profile.where(user_id: current_user.id).exists? && Phonenumber.where(user_id: current_user.id).exists? && @user_card =Card.where(user_id: current_user.id).exists?
 
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -3,7 +3,7 @@ class ApplicationController < ActionController::Base
   protect_from_forgery with: :exception
   before_action :configure_permitted_parameters, if: :devise_controller?
   before_action :set_search
-
+  before_action :delete_user, if: :user_signed_in?
   private
 
   def production?
@@ -23,6 +23,14 @@ class ApplicationController < ActionController::Base
   def set_search
     @search = Item.ransack(params[:q])
     @items = @search.result.limit(4).order("created_at DESC")
+  end
+
+  def delete_user
+    @user_profile =Profile.where(user_id: current_user.id)
+    @user_phonenumber = Phonenumber.where(user_id: current_user.id)
+    @registrations=User.find(current_user.id)
+    @registrations.destroy if Profile.where(user_id: current_user.id).empty? || Phonenumber.where(user_id: current_user.id).empty? || @user_card =Card.where(user_id: current_user.id).empty?
+
   end
 end
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -27,7 +27,8 @@ class ApplicationController < ActionController::Base
 
   def delete_user
     @registrations=User.find(current_user.id)
-    @registrations.destroy if Profile.where(user_id: current_user.id).empty? || Phonenumber.where(user_id: current_user.id).empty? || @user_card =Card.where(user_id: current_user.id).empty?
+    binding.pry
+    @registrations.destroy unless Profile.where(user_id: current_user.id).exists? || Phonenumber.where(user_id: current_user.id).exists? || @user_card =Card.where(user_id: current_user.id).exists?
 
   end
 end

--- a/app/controllers/creditcards_controller.rb
+++ b/app/controllers/creditcards_controller.rb
@@ -1,5 +1,6 @@
 class CreditcardsController < ApplicationController
   protect_from_forgery except:  [:create]
+  skip_before_action :delete_user
   def index
   end
 

--- a/app/controllers/phonenumber_controller.rb
+++ b/app/controllers/phonenumber_controller.rb
@@ -1,4 +1,5 @@
 class PhonenumberController < ApplicationController
+  skip_before_action :delete_user
   def new
     @phonenumber=Phonenumber.new
   end
@@ -13,10 +14,6 @@ class PhonenumberController < ApplicationController
   end
 
   private
-
-  def quit_registrations
-  redirect_to controller: 'users', action: 'destroy', id: current_user.id
-  end
 
   def phonenumber_params
     params.require(:phonenumber).permit(:phonenumber).merge(user_id: current_user.id)

--- a/app/views/shared/_header.html.haml
+++ b/app/views/shared/_header.html.haml
@@ -25,7 +25,7 @@
           = render 'shared/brand-accordion'
       .inner-header__under__right
         - if user_signed_in?
-          - if @user_profile.present? && @user_phonenumber.present?
+          - if current_user.profile.present? && @current_user.phonenumber.present?
             .inner-header__under__right__notice
               %i.fas.fa-bell
               .inner-header__under__right__notice__text お知らせ

--- a/app/views/shared/_header.html.haml
+++ b/app/views/shared/_header.html.haml
@@ -25,22 +25,28 @@
           = render 'shared/brand-accordion'
       .inner-header__under__right
         - if user_signed_in?
-          .inner-header__under__right__notice
-            %i.fas.fa-bell
-            .inner-header__under__right__notice__text お知らせ
-            = render 'shared/notice-accordion'
-            .inner-header__under__right__notice__circle 99+
-          .inner-header__under__right__to-do-list
-            %i.fas.fa-check
-            .inner-header__under__right__to-do-list__text やることリスト
-            .inner-header__under__right__to-do-list__accordion
-              .inner-header__under__right__to-do-list__accordion__image
-                = image_tag "to-do-list.png" ,width: "280px"
-          .inner-header__under__right__my-page
-            = image_tag "member_photo_noimage_thumb.png" ,size: "32x32",class: "user-icon-image-top"
-            .inner-header__under__right__my-page__text
-              = link_to "マイページ",user_path(current_user.id)
-            = render 'shared/mypage-accordion'
+          - if @user_profile.present? && @user_phonenumber.present?
+            .inner-header__under__right__notice
+              %i.fas.fa-bell
+              .inner-header__under__right__notice__text お知らせ
+              = render 'shared/notice-accordion'
+              .inner-header__under__right__notice__circle 99+
+            .inner-header__under__right__to-do-list
+              %i.fas.fa-check
+              .inner-header__under__right__to-do-list__text やることリスト
+              .inner-header__under__right__to-do-list__accordion
+                .inner-header__under__right__to-do-list__accordion__image
+                  = image_tag "to-do-list.png" ,width: "280px"
+            .inner-header__under__right__my-page
+              = image_tag "member_photo_noimage_thumb.png" ,size: "32x32",class: "user-icon-image-top"
+              .inner-header__under__right__my-page__text
+                = link_to "マイページ",user_path(current_user.id)
+              = render 'shared/mypage-accordion'
+          - else
+            .inner-header__under__right__new
+              = link_to 'ログイン', new_user_session_path
+            .inner-header__under__right__login
+              = link_to '新規会員登録', new_user_path
         - else
           .inner-header__under__right__new
             = link_to 'ログイン', new_user_session_path

--- a/app/views/users/complete.html.haml
+++ b/app/views/users/complete.html.haml
@@ -27,7 +27,7 @@
         ありがとうございます。
         .signin__user-infomation__complete
         会員登録が完了しました。
-        .signin__user-information__byn
-          = link_to "メルカリを始める。", root_path,class: "signin__user-information__byn__start"
+        .signin__user-infomation__btn
+          = link_to "メルカリを始める。", root_path,class: "signin__user-infomation__btn__start"
   =render 'shared/mercari-footer'
 


### PR DESCRIPTION
# what
マルチステップフォームの修正

# why
　現在newとcreateの繰り返しにより1ページごとにデータを保存して次のフォームに遷移する。
　この保存方法の問題としてユーザーが途中でやめた時にもデータが保存される状態である。
　この問題を解消するために、完全に登録が終わっていない時に電話番号登録、住所登録、クレジットカード登録以外のアクションが実行された場合にユーザー情報を削除する実装を行なった。
