### PR TITLE
エラー文の通りに修正　デプロイバグ修正　gem 変更

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,7 +13,7 @@ gem 'mysql2', '>= 0.3.18', '< 0.6.0'
 # Use Puma as the app server
 gem 'puma', '~> 3.0'
 # Use SCSS for stylesheets
-gem 'sass-rails', '~> 5.0'
+# gem 'sass-rails', '~> 5.0'
 # Use Uglifier as compressor for JavaScript assets
 # gem 'uglifier', '>= 1.3.0'・
 # Use CoffeeScript for .coffee assets and views
@@ -88,3 +88,5 @@ gem 'omniauth'
 gem 'omniauth-facebook'
 gem 'omniauth-google-oauth2'
 gem 'recaptcha', require: "recaptcha/rails"
+gem 'sassc-rails'
+gem 'sassc'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -301,17 +301,15 @@ GEM
     rspec-support (3.8.0)
     ruby_parser (3.13.1)
       sexp_processor (~> 4.9)
-    sass (3.7.4)
-      sass-listen (~> 4.0.0)
-    sass-listen (4.0.0)
-      rb-fsevent (~> 0.9, >= 0.9.4)
-      rb-inotify (~> 0.9, >= 0.9.7)
-    sass-rails (5.0.7)
-      railties (>= 4.0.0, < 6)
-      sass (~> 3.1)
-      sprockets (>= 2.8, < 4.0)
-      sprockets-rails (>= 2.0, < 4.0)
-      tilt (>= 1.1, < 3)
+    sassc (2.0.1)
+      ffi (~> 1.9)
+      rake
+    sassc-rails (2.1.0)
+      railties (>= 4.0.0)
+      sassc (>= 2.0)
+      sprockets (> 3.0)
+      sprockets-rails
+      tilt
     sexp_processor (4.12.0)
     spring (2.0.2)
       activesupport (>= 4.2)
@@ -396,7 +394,8 @@ DEPENDENCIES
   ransack
   recaptcha
   rspec-rails
-  sass-rails (~> 5.0)
+  sassc
+  sassc-rails
   spring
   spring-watcher-listen (~> 2.0.0)
   turbolinks (~> 5)


### PR DESCRIPTION
# Waht
gem sass  を削除（コメントアウト）

以下２つのgem追加
gem sassc-rails
gem sassc
ローカルでは問題なく動きます

# Why
デプロイ環境でエラーが発生し
エラー文で指示があったため
sassは廃止予定のためもう使用できません

ターミナルエラー文
https://gyazo.com/f21a0d9626ad7d76ffa167afd743ce76

提案されたサイト
http://sass.logdown.com/posts/7828841
https://sass-lang.com/install